### PR TITLE
Documentation

### DIFF
--- a/bin/normalizeWadl.sh
+++ b/bin/normalizeWadl.sh
@@ -56,10 +56,11 @@ function saxonize {
 function USAGE()
 {
     echo ""
-    echo "Usage: $(basename $0) [-?fvx] -w wadlFile"
+    echo "Usage: $(basename $0) [-?dfvx] -w wadlFile"
     echo ""
     echo "OPTIONS:"
     echo "       -w wadlFile: The wadl file to normalize."
+    echo "       -d omit or keep. Exclude/keep Wadl documentation. (keep by default)."     
     echo "       -f Wadl format. path or tree"
     echo "          path: Format resources in path format, "
     echo "                e.g. <resource path='foo/bar'/>"
@@ -75,17 +76,19 @@ function USAGE()
 
 xsdVersion=1.1
 flattenXsds=true
+documentation=keep
 resource_types=keep
 
 #PROCESS ARGS
-while getopts ":v:w:f:x:r:?" Option
+while getopts ":v:w:d:f:x:r:?" Option
 do
     case $Option in
         v    ) xsdVersion=$OPTARG;;
         w    ) wadlFile=$OPTARG;;
+        d    ) documentation=$OPTARG;;        
         f    ) wadlFormat=$OPTARG;;
         x    ) flattenXsds=$OPTARG;;
-	r    ) resource_types=$OPTARG;;
+	    r    ) resource_types=$OPTARG;;
         ?    ) USAGE
                exit 0;;
         *    ) echo ""
@@ -94,7 +97,8 @@ do
     esac
 done
 
-if [[ -f "$wadlFile" && ( ! -n $wadlFormat || $wadlFormat = "path" || $wadlFormat = "tree")]]
+if [[ -f "$wadlFile" && ( ! -n $wadlFormat || $wadlFormat = "path" || $wadlFormat = "tree" ) &&
+(! -n $documentation || $documentation = "keep" || $documentation = "omit" )]]
 then 
     [ -d "$(dirname $wadlFile)/normalized" ] || mkdir $(dirname $wadlFile)/normalized
 
@@ -107,7 +111,7 @@ then
 
 
     # Process the document wadl document.
-    saxonize $wadlFile normalizeWadl.xsl $(dirname $wadlFile)/normalized/$(basename ${wadlFile%%.wadl}.wadl) "$wadlFormat" xsdVersion=$xsdVersion flattenXsds=$flattenXsds resource_types=$resource_types
+    saxonize $wadlFile normalizeWadl.xsl $(dirname $wadlFile)/normalized/$(basename ${wadlFile%%.wadl}.wadl) "$wadlFormat" xsdVersion=$xsdVersion flattenXsds=$flattenXsds resource_types=$resource_types documentation=$documentation
 
     # Validate the output wadl.
     xmllint --noout --schema "$DIR/../xsd/wadl.xsd"  $(dirname $wadlFile)/normalized/$(basename ${wadlFile%%.wadl}.wadl)

--- a/src/main/scala/wadl-normalizer.scala
+++ b/src/main/scala/wadl-normalizer.scala
@@ -7,6 +7,12 @@ object WADLFormat extends Enumeration {
   val DONT = Value("dont-format")
 }
 
+object DOCType extends Enumeration {
+  type DocumentationType = Value
+  val KEEPIT = Value("keep")
+  val OMITIT = Value("omit")
+}
+
 object RType extends Enumeration {
   type ResourceType = Value
   val KEEP = Value("keep")
@@ -20,6 +26,7 @@ object XSDVersion extends Enumeration {
 }
 
 import WADLFormat._
+import DOCType._
 import RType._
 import XSDVersion._
 import Converters._
@@ -101,14 +108,17 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
 
   def newTransformer(format : Format,
                      xsdVersion : Version,
-                     flattenXSDs : Boolean,
-		               resource_types : ResourceType) : Transformer = {
+                     flattenXSDs : Boolean,  
+                     documentation : DocumentationType,       
+		             resource_types : ResourceType) : Transformer = {
     val transformer = newTransformer
 
     transformer.setParameter("format",format.toString())
     transformer.setParameter("xsdVersion", xsdVersion.toString())
-    transformer.setParameter("resource_types", resource_types.toString())
     transformer.setParameter("flattenXsds", flattenXSDs.toString())
+    transformer.setParameter("documentation", documentation.toString())
+    transformer.setParameter("resource_types", resource_types.toString())
+    
 
     transformer
   }
@@ -122,9 +132,10 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                     format : Format,
                     xsdVersion : Version,
                     flattenXSDs : Boolean,
+                    documentation : DocumentationType,
 		              resource_types : ResourceType) : Unit = {
 
-    val transformer = newTransformer(format, xsdVersion, flattenXSDs, resource_types)
+    val transformer = newTransformer(format, xsdVersion, flattenXSDs, documentation, resource_types)
     transformer.transform (in, out)
   }
 
@@ -136,12 +147,13 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format,
                 xsdVersion : Version,
                 flattenXSDs : Boolean,
+                documentation : DocumentationType,                 
 		          resource_types : ResourceType) : Unit = {
     val xmlReader = newSAXParser.getXMLReader()
     val inputSource = new InputSource(in._2)
     inputSource.setSystemId(in._1)
     normalize (new SAXSource(xmlReader, inputSource), out,
-               format, xsdVersion, flattenXSDs,
+               format, xsdVersion, flattenXSDs, documentation,
                resource_types)
   }
 
@@ -153,9 +165,10 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format,
                 xsdVersion : Version,
                 flattenXSDs : Boolean,
+                documentation : DocumentationType,  
 		          resource_types : ResourceType) : Unit = {
     normalize (("",in), out, format, xsdVersion,
-               flattenXSDs, resource_types)
+               flattenXSDs, documentation, resource_types)
   }
 
   //
@@ -166,10 +179,11 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format,
                 xsdVersion : Version,
                 flattenXSDs : Boolean,
+                documentation : DocumentationType,  
 		          resource_types : ResourceType) : Unit = {
     val xmlReader = newSAXParser.getXMLReader()
     normalize (new SAXSource(xmlReader, new InputSource(in)), out,
-               format, xsdVersion, flattenXSDs,
+               format, xsdVersion, flattenXSDs, documentation,
                resource_types)
   }
 
@@ -181,10 +195,11 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format,
                 xsdVersion : Version,
                 flattenXSDs : Boolean,
+                documentation : DocumentationType,  
 		          resource_types : ResourceType) : Unit = {
     val xmlReader = newSAXParser.getXMLReader()
     normalize (new SAXSource(xmlReader, new InputSource(in)), out,
-               format, xsdVersion, flattenXSDs,
+               format, xsdVersion, flattenXSDs, documentation,
                resource_types)
   }
 
@@ -197,10 +212,12 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format,
                 xsdVersion : Version,
                 flattenXSDs : Boolean,
+                documentation : DocumentationType,  
 		          resource_types : ResourceType) : NodeSeq = {
     val bytesOut = new ByteArrayOutputStream()
     normalize(in, new StreamResult(bytesOut),
               format, xsdVersion, flattenXSDs,
+              documentation,
               resource_types);
     XML.loadString (bytesOut.toString())
   }
@@ -213,8 +230,10 @@ class WADLNormalizer(private var transformerFactory : TransformerFactory) {
                 format : Format = DONT,
                 xsdVersion : Version = XSD11,
                 flattenXSDs : Boolean = false,
+                documentation : DocumentationType=KEEPIT,  
 		          resource_types : ResourceType = KEEP) : NodeSeq = {
-    normalize(("", in), format, xsdVersion, flattenXSDs, resource_types)
+    normalize(("", in), format, xsdVersion, flattenXSDs, documentation, resource_types)
   }
+
 
 }

--- a/src/test/scala/flat-xsd-tests.scala
+++ b/src/test/scala/flat-xsd-tests.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.ShouldMatchers._
 
 import com.rackspace.cloud.api.wadl.WADLFormat._
 import com.rackspace.cloud.api.wadl.XSDVersion._
+import com.rackspace.cloud.api.wadl.DOCType._
 import com.rackspace.cloud.api.wadl.RType._
 import com.rackspace.cloud.api.wadl.Converters._
 
@@ -87,7 +88,7 @@ class FlatXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       commonFlatSingleXSDAssertions
     }
 
@@ -123,7 +124,7 @@ class FlatXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       commonFlatSingleXSDAssertions
     }
 
@@ -185,7 +186,7 @@ class FlatXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       commonFlatImportXSDAssertions
     }
 
@@ -230,7 +231,7 @@ class FlatXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       commonFlatImportXSDAssertions
     }
 

--- a/src/test/scala/test-omit-doc.scala
+++ b/src/test/scala/test-omit-doc.scala
@@ -15,12 +15,96 @@ import com.rackspace.cloud.api.wadl.Converters._
 class OmitWADLDocumentation extends BaseWADLSpec {
 
 
-  feature ("The WADL normalizer can convert WADL resources into a tree format") {
+  feature ("The WADL normalizer can omit or retain documentation") {
 
     info("As a developer")
-    info("I want to be able to omit all documentation in a WADL")
+    info("I want to be able to retain or omit all documentation in a WADL")
 
-    scenario ("The original WADL contains documentation") {
+    scenario ("The original WADL contains documentation and I want to keep it") {
+      given("a WADL with documentation")
+      val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <resources base="https://test.api.openstack.com">
+              <resource path="a" queryType="application/x-www-form-urlencoded">
+                <doc xml:lang="EN" title="Detail Image List">
+                    <p xmlns="http://www.w3.org/1999/xhtml">
+                        A Random comment
+                    </p>
+                </doc>
+                <resource path="b">
+                  <resource path="c"/>
+                </resource>
+              </resource>
+              <resource path="d">
+                <doc xml:lang="EN" title="Detail Image List">
+                    <p xmlns="http://www.w3.org/1999/xhtml">
+                        Another Random comment
+                    </p>
+                </doc>              
+                <resource path="e"/>
+              </resource>
+              <resource path="f"/>
+	      <resource path="g"/>
+	      <resource path="h">
+	      <resource path="i">
+		<resource path="{j}">
+		   <param name="j" style="template" type="xsd:string" required="true"/>
+		   <resource path="k">
+		      <method href="#foo"/>
+		      <resource path="l">
+			 <method href="#foo"/>
+		      </resource>
+		   </resource>
+		</resource>
+	      </resource>
+	      </resource>
+            </resources>
+            <method name="GET" id="foo"/>
+        </application>
+      val outWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <resources base="https://test.api.openstack.com">
+              <resource path="a" queryType="application/x-www-form-urlencoded">
+                <resource queryType="application/x-www-form-urlencoded" path="b">
+                  <resource queryType="application/x-www-form-urlencoded" path="c"/>
+                </resource>
+              </resource>
+              <resource queryType="application/x-www-form-urlencoded" path="d">
+                <resource queryType="application/x-www-form-urlencoded" path="e"/>
+              </resource>
+              <resource queryType="application/x-www-form-urlencoded" path="f"/>
+	      <resource queryType="application/x-www-form-urlencoded" path="g"/>
+	      <resource queryType="application/x-www-form-urlencoded" path="h">
+	      <resource queryType="application/x-www-form-urlencoded" path="i">
+		<resource queryType="application/x-www-form-urlencoded" path="{j}">
+		   <param name="j" style="template" type="xsd:string" required="true" repeating="false"/>
+		   <resource queryType="application/x-www-form-urlencoded" path="k">
+		      <method name="GET" xmlns:rax="http://docs.rackspace.com/api" rax:id="foo"/>
+		      <resource queryType="application/x-www-form-urlencoded" path="l">
+			 <method name="GET" xmlns:rax="http://docs.rackspace.com/api" rax:id="foo"/>
+		      </resource>
+		   </resource>
+		</resource>
+	      </resource>
+	      </resource>
+            </resources>
+            <method name="GET" id="foo"/>
+        </application>
+        
+        
+      when("the WADL is normalized")
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, false, KEEPIT, KEEP)
+      assertWADL(normWADL)
+      assertWADL(outWADL)
+      then("the resources should remain unchanged")
+      canon(outWADL) should not equal (canon(normWADL))
+      
+    }
+
+
+    scenario ("The original WADL contains documentation and we want to omit it") {
       given("a WADL with documentation")
       val inWADL =
         <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -100,6 +184,7 @@ class OmitWADLDocumentation extends BaseWADLSpec {
       assertWADL(outWADL)
       then("the resources should remain unchanged")
       canon(outWADL) should equal (canon(normWADL))
+      
     }
 
 

--- a/src/test/scala/test-omit-doc.scala
+++ b/src/test/scala/test-omit-doc.scala
@@ -1,0 +1,108 @@
+package com.rackspace.cloud.api.wadl.test
+
+import scala.xml._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers._
+
+import com.rackspace.cloud.api.wadl.WADLFormat._
+import com.rackspace.cloud.api.wadl.XSDVersion._
+import com.rackspace.cloud.api.wadl.DOCType._
+import com.rackspace.cloud.api.wadl.RType._
+import com.rackspace.cloud.api.wadl.Converters._
+
+@RunWith(classOf[JUnitRunner])
+class OmitWADLDocumentation extends BaseWADLSpec {
+
+
+  feature ("The WADL normalizer can convert WADL resources into a tree format") {
+
+    info("As a developer")
+    info("I want to be able to omit all documentation in a WADL")
+
+    scenario ("The original WADL contains documentation") {
+      given("a WADL with documentation")
+      val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <resources base="https://test.api.openstack.com">
+              <resource path="a" queryType="application/x-www-form-urlencoded">
+                <doc xml:lang="EN" title="Detail Image List">
+                    <p xmlns="http://www.w3.org/1999/xhtml">
+                        A Random comment
+                    </p>
+                </doc>
+                <resource path="b">
+                  <resource path="c"/>
+                </resource>
+              </resource>
+              <resource path="d">
+                <doc xml:lang="EN" title="Detail Image List">
+                    <p xmlns="http://www.w3.org/1999/xhtml">
+                        Another Random comment
+                    </p>
+                </doc>              
+                <resource path="e"/>
+              </resource>
+              <resource path="f"/>
+	      <resource path="g"/>
+	      <resource path="h">
+	      <resource path="i">
+		<resource path="{j}">
+		   <param name="j" style="template" type="xsd:string" required="true"/>
+		   <resource path="k">
+		      <method href="#foo"/>
+		      <resource path="l">
+			 <method href="#foo"/>
+		      </resource>
+		   </resource>
+		</resource>
+	      </resource>
+	      </resource>
+            </resources>
+            <method name="GET" id="foo"/>
+        </application>
+      val outWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <resources base="https://test.api.openstack.com">
+              <resource path="a" queryType="application/x-www-form-urlencoded">
+                <resource queryType="application/x-www-form-urlencoded" path="b">
+                  <resource queryType="application/x-www-form-urlencoded" path="c"/>
+                </resource>
+              </resource>
+              <resource queryType="application/x-www-form-urlencoded" path="d">
+                <resource queryType="application/x-www-form-urlencoded" path="e"/>
+              </resource>
+              <resource queryType="application/x-www-form-urlencoded" path="f"/>
+	      <resource queryType="application/x-www-form-urlencoded" path="g"/>
+	      <resource queryType="application/x-www-form-urlencoded" path="h">
+	      <resource queryType="application/x-www-form-urlencoded" path="i">
+		<resource queryType="application/x-www-form-urlencoded" path="{j}">
+		   <param name="j" style="template" type="xsd:string" required="true" repeating="false"/>
+		   <resource queryType="application/x-www-form-urlencoded" path="k">
+		      <method name="GET" xmlns:rax="http://docs.rackspace.com/api" rax:id="foo"/>
+		      <resource queryType="application/x-www-form-urlencoded" path="l">
+			 <method name="GET" xmlns:rax="http://docs.rackspace.com/api" rax:id="foo"/>
+		      </resource>
+		   </resource>
+		</resource>
+	      </resource>
+	      </resource>
+            </resources>
+            <method name="GET" id="foo"/>
+        </application>
+        
+        
+      when("the WADL is normalized")
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, false, OMITIT, KEEP)
+      assertWADL(normWADL)
+      assertWADL(outWADL)
+      then("the resources should remain unchanged")
+      canon(outWADL) should equal (canon(normWADL))
+    }
+
+
+
+  }
+}

--- a/src/test/scala/wadl-tests.scala
+++ b/src/test/scala/wadl-tests.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.ShouldMatchers._
 
 import com.rackspace.cloud.api.wadl.WADLFormat._
 import com.rackspace.cloud.api.wadl.XSDVersion._
+import com.rackspace.cloud.api.wadl.DOCType._
 import com.rackspace.cloud.api.wadl.RType._
 import com.rackspace.cloud.api.wadl.Converters._
 
@@ -163,7 +164,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
             <method id="foo"/>
         </application>
       when("the WADL is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, OMIT)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, OMIT)
       then("the resources should be the same except that resource_types and links to resource_types are omitted")
       canon(outWADL) should equal (canon(normWADL))
     }
@@ -283,7 +284,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
              <method id="foo"/>
         </application>
       when("the WADL is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, OMIT)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, OMIT)
       then("the resources should now be in tree format")
       canon(treeWADL) should equal (canon(normWADL))
     }
@@ -416,7 +417,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
    <method id="foo"/>
 </application>
       when("the WADL is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, OMIT)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, OMIT)
       then("the resources should now be in tree format with resource_types and links to resource_types omitted")
       canon(treeWADL) should equal (canon(normWADL))
     }
@@ -445,7 +446,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
            </resources>
         </application>
       when ("The wadl is normalized")
-      val normWADL  = wadl.normalize(inWADL, TREE, XSD11, false, OMIT)
+      val normWADL  = wadl.normalize(inWADL, TREE, XSD11, false, KEEPIT, OMIT)
       then ("The extension attribute should be preserved")
       assert (normWADL, "//wadl:resource[@path='path' and @rax:invisible='true']")
       assert (normWADL, "//wadl:resource[@path='to' and @rax:invisible='true']")
@@ -501,7 +502,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
            </resources>
         </application>
       then("the normalize wadls should be equivalent if converted to TREE format")
-      canon(wadl.normalize(inWADL, TREE, XSD11, true, OMIT)) should equal (canon(wadl.normalize(inWADL2, TREE, XSD11, true, OMIT)))
+      canon(wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, OMIT)) should equal (canon(wadl.normalize(inWADL2, TREE, XSD11, true, KEEPIT, OMIT)))
     }
 
     scenario ("The original WADL contains paths starting and ending  with / to be converted to PATH format"){
@@ -548,7 +549,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
            </resources>
         </application>
       then("the normalize wadls should be equivalent if converted to PATH format")
-      canon(wadl.normalize(inWADL, PATH, XSD11, true, OMIT)) should equal (canon(wadl.normalize(inWADL2, PATH, XSD11, true, OMIT)))
+      canon(wadl.normalize(inWADL, PATH, XSD11, true, KEEPIT, OMIT)) should equal (canon(wadl.normalize(inWADL2, PATH, XSD11, true, KEEPIT, OMIT)))
     }
 
     scenario ("The original WADL contains paths prefixed with / to with the format unchanged"){
@@ -595,7 +596,7 @@ class NormalizeWADLSpec extends BaseWADLSpec {
            </resources>
         </application>
       then("the normalize wadls should be equivalent if the format is unchnaged")
-      canon(wadl.normalize(inWADL, DONT, XSD11, true, OMIT)) should equal (canon(wadl.normalize(inWADL2, DONT, XSD11, true, OMIT)))
+      canon(wadl.normalize(inWADL, DONT, XSD11, true, KEEPIT, OMIT)) should equal (canon(wadl.normalize(inWADL2, DONT, XSD11, true, KEEPIT, OMIT)))
     }
 
     //

--- a/src/test/scala/xsd-1-1-tests.scala
+++ b/src/test/scala/xsd-1-1-tests.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.ShouldMatchers._
 
 import com.rackspace.cloud.api.wadl.WADLFormat._
 import com.rackspace.cloud.api.wadl.XSDVersion._
+import com.rackspace.cloud.api.wadl.DOCType._
 import com.rackspace.cloud.api.wadl.RType._
 import com.rackspace.cloud.api.wadl.Converters._
 
@@ -42,7 +43,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       then("No additonal documents should be produced")
       outputs.size should equal (0)
     }
@@ -102,7 +103,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -135,7 +136,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -169,7 +170,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -204,7 +205,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -236,7 +237,7 @@ class NormalizeXSD11Spec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD11, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //

--- a/src/test/scala/xsd-tests.scala
+++ b/src/test/scala/xsd-tests.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.ShouldMatchers._
 
 import com.rackspace.cloud.api.wadl.WADLFormat._
 import com.rackspace.cloud.api.wadl.XSDVersion._
+import com.rackspace.cloud.api.wadl.DOCType._
 import com.rackspace.cloud.api.wadl.RType._
 import com.rackspace.cloud.api.wadl.Converters._
 
@@ -42,7 +43,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       then("No additonal documents should be produced")
       outputs.size should equal (0)
     }
@@ -95,7 +96,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -126,7 +127,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, false, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, false, KEEPIT, KEEP)
       //
       //  Assert that the output wadl contains a grammars/inlude element pointing to the schema
       //
@@ -159,7 +160,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -191,7 +192,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -224,7 +225,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //
@@ -255,7 +256,7 @@ class NormalizeXSDSpec extends BaseWADLSpec {
             </resources>
         </application>)
       when("the wadl is normalized")
-      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEP)
+      val normWADL = wadl.normalize(inWADL, TREE, XSD10, true, KEEPIT, KEEP)
       //
       //  Call the common assertions above...
       //

--- a/xsl/normalizeWadl1.xsl
+++ b/xsl/normalizeWadl1.xsl
@@ -31,7 +31,9 @@
     <xsl:param name="xsdVersion" select="xs:decimal(1.1)"/>
 
     <xsl:param name="flattenXsds">true</xsl:param>
-
+    
+    <xsl:param name="documentation"></xsl:param>
+    
     <xsl:param name="debug">0</xsl:param>
     <xsl:param name="format">-format</xsl:param>
 
@@ -382,6 +384,17 @@
 
     <!-- End prune-imports mode templates -->
 
+
+    <xsl:template match="wadl:doc" mode="normalizeWadl2">
+        <xsl:choose>
+            <xsl:when test="$documentation = 'omit'"/>            
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@*|node()" mode="normalizeWadl2"/>
+                </xsl:copy>
+            </xsl:otherwise>                
+        </xsl:choose>
+    </xsl:template>
 
     <xsl:template match="wadl:grammars" mode="normalizeWadl2">
       <xsl:choose>


### PR DESCRIPTION
-Edited normalizeWadl1.xsl with new paramter: documentation which allows for the omission of wadl documentation.

-Added new option for the normailzeWadl.sh script (-d omit|keep). -d omit ignores all <doc> elements in the wadl and the normailzed output is stripped of documentation.  -d keep retains all wadl documentation, by default the value is keep.

-Also added scala tests to accept the new parameter: documentation

-Changed existing scala test calls to adhere to the new documentation parameter