### PR TITLE
Address rax:roles bug (#126)

### DIFF
--- a/src/test/scala/wadl-tests-ext.scala
+++ b/src/test/scala/wadl-tests-ext.scala
@@ -39,7 +39,8 @@ class NormalizeWADLEXTSpec extends BaseWADLSpec {
                   <method name="DELETE" rax:roles="b:observer b:admin"/>
               </resource>
            </resource>
-          </resources>
+          <resource path="/c/d" rax:roles="a:anotherRole"/>
+        </resources>
        </application>
 
        val inWADLWithReferences = <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
@@ -52,7 +53,8 @@ class NormalizeWADLEXTSpec extends BaseWADLSpec {
                      <method href="#deleteOnB" rax:roles="b:observer b:admin"/>
                    </resource>
                </resource>
-             </resources>
+              <resource path="/c/d" rax:roles="a:anotherRole"/>
+            </resources>
              <method id="putOnA" name="PUT"/>
              <method id="postOnB" name="POST"/>
              <method id="putOnB" name="PUT" rax:roles="b:observer"/>
@@ -68,10 +70,14 @@ class NormalizeWADLEXTSpec extends BaseWADLSpec {
       assert (normWADLNoRefs,"not(exists(/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='POST']/@rax:roles))")
       assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='PUT']/@rax:roles = 'b:observer'")
       assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='DELETE']/@rax:roles = 'b:observer b:admin'")
+      assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/@rax:roles = 'a:anotherRole'")
+      assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/@rax:roles != 'a:anotherRole' and @path = 'c'") //Raxroles should not apply to previous resources
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:method/@rax:roles = 'a:observer'")
       assert (normWADLRefs,"not(exists(/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='POST']/@rax:roles))")
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='PUT']/@rax:roles = 'b:observer'")
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='DELETE']/@rax:roles = 'b:observer b:admin'")
+      assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/@rax:roles = 'a:anotherRole'")
+      assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/@rax:roles != 'a:anotherRole' and @path = 'c'") //Raxroles should not apply to previous resources
     }
   }
 

--- a/src/test/scala/wadl-tests-ext.scala
+++ b/src/test/scala/wadl-tests-ext.scala
@@ -71,13 +71,13 @@ class NormalizeWADLEXTSpec extends BaseWADLSpec {
       assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='PUT']/@rax:roles = 'b:observer'")
       assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='DELETE']/@rax:roles = 'b:observer b:admin'")
       assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/@rax:roles = 'a:anotherRole'")
-      assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource/@rax:roles != 'a:anotherRole' and @path = 'c'") //Raxroles should not apply to previous resources
+      assert (normWADLNoRefs,"/wadl:application/wadl:resources/wadl:resource[not(@rax:roles = 'a:anotherRole') and @path = 'c']") //Raxroles should not apply to previous resources
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:method/@rax:roles = 'a:observer'")
       assert (normWADLRefs,"not(exists(/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='POST']/@rax:roles))")
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='PUT']/@rax:roles = 'b:observer'")
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/wadl:method[@name='DELETE']/@rax:roles = 'b:observer b:admin'")
       assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/wadl:resource/@rax:roles = 'a:anotherRole'")
-      assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource/@rax:roles != 'a:anotherRole' and @path = 'c'") //Raxroles should not apply to previous resources
+      assert (normWADLRefs,"/wadl:application/wadl:resources/wadl:resource[not(@rax:roles = 'a:anotherRole') and @path = 'c']") //Raxroles should not apply to previous resources
     }
   }
 

--- a/xsl/normalizeWadl3.xsl
+++ b/xsl/normalizeWadl3.xsl
@@ -130,12 +130,17 @@ This XSLT flattens or expands the path in the path attributes of the resource el
         <xsl:param name="resources"/>
         <xsl:for-each-group select="$resources" group-by="wadl:tokens/wadl:token[$token-number]">
             <resource path="{current-grouping-key()}">
-                <xsl:copy-of select="self::wadl:resource/@*[not(local-name(.) = 'path') and not(local-name(.) = 'id')]"/>
+                <!-- Copy all attributes except for special cases: @path, @id, and @rax:roles -->
+                <xsl:copy-of select="self::wadl:resource/@*[not(local-name(.) = 'path') and not(local-name(.) = 'id') and not(name(.) = 'rax:roles')]"/>
                 <xsl:choose>
                     <xsl:when test="@id and not($token-number = 1)"><xsl:attribute name="id" select="concat(@id,'-', $token-number )"/></xsl:when>
                     <xsl:when test="@id"><xsl:attribute name="id" select="@id"/></xsl:when>	
                     <xsl:when test="count(wadl:tokens/wadl:token) = $token-number"><xsl:attribute name="id" select="raxf:generate-resource-id(.)"/></xsl:when>
                 </xsl:choose>
+                <xsl:if test="count(wadl:tokens/wadl:token) = $token-number">
+                <!-- Only copy @rax:roles if we're on the leaf of the tree of wadl:resource elements -->
+                    <xsl:copy-of select="@rax:roles"/>
+                </xsl:if>
                 <xsl:apply-templates select="wadl:param[@style = 'template']" mode="tree-format">
                     <xsl:with-param name="path" select="current-grouping-key()"/>
                 </xsl:apply-templates>	      


### PR DESCRIPTION
Only copy rax:roles attribute to wadl:resource elements on the final/leaf wadl:resource element when converting from path format to tree format. 