### PR TITLE
Double slash in root //  still causes issues.

### DIFF
--- a/src/test/scala/wadl-tests-slash.scala
+++ b/src/test/scala/wadl-tests-slash.scala
@@ -27,32 +27,70 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
     info("I want to ignore extra slashes in the WADL cus they happen all the time and they are irrelevent")
     info("So that I can normalize a WADL without worrying about cleaning extra slashes up.")
 
-    scenario ("A single WADL contians extra slashes") {
-      Given("Given semantically equivilant WADLs with and without extra slashes")
-
-        def norm(n : NodeSeq) : NodeSeq = {
-	  wadl.normalize(("test://path/to/test/mywadl.wadl", n), TREE, XSD11, false, KEEP)
-	}
-
-      //
-      //  An external file with double slashes...
-      //
-       register ("test://path/to/test/other.wadl",
-		 <application xmlns="http://wadl.dev.java.net/2009/02">
-                    <resource_type id="cd">
-		     <resource path="c///d">
-			 <method name="GET"/>
-		     </resource>
-                    </resource_type>
-                 </application>)
-
-        val normWADLs = List(
-	  //
-	  //  No double slashes
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
+    val testWadls : List[(String, NodeSeq, Option[(String, NodeSeq)])] =
+      List(
+        ("No double slashes",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
         <resources base="https://test.api.openstack.com">
-          <resource path="/a">
+          <resource path="/">
+             <method name="GET"/>
+          </resource>
+          <resource path="/">
+             <method name="POST"/>
+               <resource path="/a">
+                 <method name="PUT"/>
+                   <resource path="/b">
+                       <method name="POST"/>
+                       <method name="PUT"/>
+                       <method name="DELETE"/>
+                   </resource>
+               </resource>
+          </resource>
+          <resource path="/a/b/c/d">
+	    <method name="GET"/>
+	  </resource>
+	  <resource path="/foo">
+	      <method name="GET"/>
+	      <resource path="bar">
+		  <method name="POST"/>
+	      </resource>
+	  </resource>
+        </resources>
+       </application>, None),
+       ("No double slashes : root defined elsewhere",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
+        <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+          <method name="PUT"/>
+          <resource path="/b">
+              <method name="POST"/>
+              <method name="PUT"/>
+              <method name="DELETE"/>
+          </resource>
+         </resource>
+          <resource path="/a/b/c/d">
+	    <method name="GET"/>
+	  </resource>
+          <resource path="/">
+            <method name="GET"/>
+            <method name="POST"/>
+	    <resource path="/foo">
+	      <method name="GET"/>
+	      <resource path="bar">
+		  <method name="POST"/>
+	      </resource>
+	    </resource>
+          </resource>
+        </resources>
+       </application>, None),
+        ("Double slash in the root",
+         <application xmlns="http://wadl.dev.java.net/2009/02">
+        <resources base="https://test.api.openstack.com">
+          <resource path="//">
+             <method name="GET"/>
+             <method name="POST"/>
+          </resource>
+          <resource path="///a">
               <method name="PUT"/>
               <resource path="/b">
                   <method name="POST"/>
@@ -70,12 +108,14 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
 	      </resource>
 	  </resource>
         </resources>
-       </application>),
-	  //
-	  //  Double slashes at the end of the path
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
+       </application>, None),
+       ("Double slashes at the end of the path",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
         <resources base="https://test.api.openstack.com">
+          <resource path="/">
+             <method name="GET"/>
+             <method name="POST"/>
+          </resource>
           <resource path="/a">
               <method name="PUT"/>
               <resource path="/b//">
@@ -94,36 +134,14 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
 	      </resource>
 	  </resource>
         </resources>
-       </application>),
-	  //
-	  //  Double slashes at the end of all of the paths
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
+       </application>, None),
+       ("Double slashes in various parts of the path",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
         <resources base="https://test.api.openstack.com">
-          <resource path="/a///">
-              <method name="PUT"/>
-              <resource path="/b//">
-                  <method name="POST"/>
-                  <method name="PUT"/>
-                  <method name="DELETE"/>
-              </resource>
-           </resource>
-          <resource path="/a/b/c/d//">
-	    <method name="GET"/>
-	  </resource>
-	  <resource path="/foo//">
-	      <method name="GET"/>
-	      <resource path="bar//">
-		  <method name="POST"/>
-	      </resource>
-	  </resource>
-        </resources>
-       </application>),
-	  //
-	  //  Double slashes in various parts of the path
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
-        <resources base="https://test.api.openstack.com">
+          <resource path="/">
+             <method name="GET"/>
+             <method name="POST"/>
+          </resource>
           <resource path="/a">
               <method name="PUT"/>
               <resource path="//b">
@@ -142,13 +160,14 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
 	      </resource>
 	  </resource>
         </resources>
-       </application>),
-	  //
-	  //  Double slashes in various parts of the path, with method
-	  //  references.
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
+       </application>, None),
+       ("Double slashes in various parts of the path, with method references.",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
             <resources base="https://test.api.openstack.com">
+                <resource path="/">
+                    <method name="GET"/>
+                    <method name="POST"/>
+                </resource>
                <resource path="/a">
                  <method href="#putOnA"/>
                    <resource path="//b">
@@ -172,12 +191,14 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
              <method id="putOnB" name="PUT"/>
              <method id="deleteOnB" name="DELETE"/>
              <method id="getOnD" name="GET"/>
-           </application>),
-	  //
-	  //  Double slashes in external file
-	  //
-	  norm(<application xmlns="http://wadl.dev.java.net/2009/02">
+           </application>, None),
+       ("Double slashes in external file",
+        <application xmlns="http://wadl.dev.java.net/2009/02">
         <resources base="https://test.api.openstack.com">
+          <resource path="/">
+             <method name="GET"/>
+             <method name="POST"/>
+          </resource>
           <resource path="/a">
               <method name="PUT"/>
               <resource path="/b" type="other.wadl#cd">
@@ -193,33 +214,57 @@ class NormalizeWADLSlashSpec extends BaseWADLSpec {
 	      </resource>
 	  </resource>
         </resources>
-       </application>)
-	)
+       </application>, Some(("test://path/to/test/other.wadl",
+                             <application xmlns="http://wadl.dev.java.net/2009/02">
+                             <resource_type id="cd">
+		             <resource path="c///d">
+			     <method name="GET"/>
+		             </resource>
+                             </resource_type>
+                             </application>)))
+      )
 
-      When ("When the WADLs are normalized in tree format")
-      Then("The following XPath assertions should match")
-      normWADLs.foreach(w => {
+    testWadls.foreach (tw => {
+      val desc   = tw._1
+      val inWADL = tw._2
+      val ext    = tw._3
+
+      scenario ("Extra slashes test: "+desc) {
+        Given("Given semantically equivilant WADLs with and without extra slashes: "+desc)
+
+        ext match {
+          case Some((name, ext)) => register(name, ext)
+          case None => /* ignore */
+        }
+
+        val w = wadl.normalize(("test://path/to/test/mywadl.wadl", inWADL), TREE, XSD11, false, KEEP)
+
+        When ("When the WADLs are normalized in tree format")
+        Then("The following XPath assertions should match")
 	//
 	//  Overall structure
 	//
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']/wadl:resource[@path='d']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='foo']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='foo']/wadl:resource[@path='bar']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']/wadl:resource[@path='d']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='foo']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='foo']/wadl:resource[@path='bar']")
 
 	//
 	//  Methods
 	//
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:method[@name='PUT']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='POST']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='PUT']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='DELETE']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']/wadl:resource[@path='d']/wadl:method[@name='GET']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='foo']/wadl:method[@name='GET']")
-	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='foo']/wadl:resource[@path='bar']/wadl:method[@name='POST']")
-      })
-    }
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:method[@name='POST']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:method[@name='GET']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:method[@name='PUT']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='POST']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='PUT']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:method[@name='DELETE']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='a']/wadl:resource[@path='b']/wadl:resource[@path='c']/wadl:resource[@path='d']/wadl:method[@name='GET']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='foo']/wadl:method[@name='GET']")
+	assert (w, "/wadl:application/wadl:resources/wadl:resource[@path='/']/wadl:resource[@path='foo']/wadl:resource[@path='bar']/wadl:method[@name='POST']")
+      }
+    })
   }
 }

--- a/xsl/normalizeWadl1.xsl
+++ b/xsl/normalizeWadl1.xsl
@@ -114,7 +114,10 @@
                 <xsl:variable name="prune-params">
                     <xsl:apply-templates select="$tree-format" mode="prune-params"/>
                 </xsl:variable>
-                <xsl:apply-templates select="$prune-params" mode="join-paths"/>
+                <xsl:variable name="handle-slash">
+                     <xsl:apply-templates select="$prune-params" mode="handle-slash"/>
+                </xsl:variable>
+                <xsl:apply-templates select="$handle-slash" mode="join-paths"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="$normalizeWadl2" mode="keep-format"/>


### PR DESCRIPTION
Converting to tree fromat creates "empty" resources...

The following is enough to mess things up...

````xml
      <resource path="//" id="VersionList">
         <method xmlns:rax="http://docs.rackspace.com/api" name="GET">
            <doc title="List Versions">
                        WRITEME
                    </doc>
         </method>
      </resource>
````